### PR TITLE
Replace moderngl_window with direct pyglet window

### DIFF
--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -11,6 +11,7 @@ from contextlib import ExitStack
 import numpy as np
 from tqdm.auto import tqdm as ProgressDisplay
 from pyglet.window import key as PygletWindowKeys
+import pyglet
 
 from manimlib.animation.animation import prepare_animation
 from manimlib.camera.camera import Camera
@@ -242,11 +243,14 @@ class Scene(object):
         if self.is_window_closing():
             raise EndScene()
 
-        if self.window and dt == 0 and not self.window.has_undrawn_event() and not force_draw:
-            # In this case, there's no need for new rendering, but we
-            # shoudl still listen for new events
-            self.window._window.dispatch_events()
-            return
+        if self.window:
+            pyglet.app.platform_event_loop.dispatch_posted_events()
+            pyglet.app.platform_event_loop.step(0)
+            self.window.dispatch_events()
+            if dt == 0 and not self.window.has_undrawn_event() and not force_draw:
+                # In this case, there's no need for new rendering, but we
+                # should still listen for new events
+                return
 
         self.camera.capture(*self.render_groups)
 

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -91,6 +91,7 @@ class Window(PygletWindow):
 
     def init_mgl_context(self) -> None:
         self.ctx = moderngl.create_context()
+        self.ctx.viewport = (0, 0, self.width, self.height)
 
     # Helper properties for width/height and position
     @property
@@ -186,6 +187,11 @@ class Window(PygletWindow):
         self.flip()
         self._has_undrawn_event = False
 
+    def _dispatch_super(self, name: str, *args, **kwargs) -> None:
+        handler = getattr(super(), name, None)
+        if handler:
+            handler(*args, **kwargs)
+
     @staticmethod
     def note_undrawn_event(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
@@ -196,7 +202,7 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_mouse_motion(self, x: int, y: int, dx: int, dy: int) -> None:
-        super().on_mouse_motion(x, y, dx, dy)
+        self._dispatch_super('on_mouse_motion', x, y, dx, dy)
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
@@ -205,7 +211,7 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_mouse_drag(self, x: int, y: int, dx: int, dy: int, buttons: int, modifiers: int) -> None:
-        super().on_mouse_drag(x, y, dx, dy, buttons, modifiers)
+        self._dispatch_super('on_mouse_drag', x, y, dx, dy, buttons, modifiers)
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
@@ -214,7 +220,7 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_mouse_press(self, x: int, y: int, button: int, mods: int) -> None:
-        super().on_mouse_press(x, y, button, mods)
+        self._dispatch_super('on_mouse_press', x, y, button, mods)
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
@@ -222,7 +228,7 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_mouse_release(self, x: int, y: int, button: int, mods: int) -> None:
-        super().on_mouse_release(x, y, button, mods)
+        self._dispatch_super('on_mouse_release', x, y, button, mods)
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
@@ -230,7 +236,7 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_mouse_scroll(self, x: int, y: int, x_offset: float, y_offset: float) -> None:
-        super().on_mouse_scroll(x, y, x_offset, y_offset)
+        self._dispatch_super('on_mouse_scroll', x, y, x_offset, y_offset)
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
@@ -240,7 +246,7 @@ class Window(PygletWindow):
     @note_undrawn_event
     def on_key_press(self, symbol: int, modifiers: int) -> None:
         self.pressed_keys.add(symbol)  # Modifiers?
-        super().on_key_press(symbol, modifiers)
+        self._dispatch_super('on_key_press', symbol, modifiers)
         if not self.scene:
             return
         self.scene.on_key_press(symbol, modifiers)
@@ -248,33 +254,37 @@ class Window(PygletWindow):
     @note_undrawn_event
     def on_key_release(self, symbol: int, modifiers: int) -> None:
         self.pressed_keys.difference_update({symbol})  # Modifiers?
-        super().on_key_release(symbol, modifiers)
+        self._dispatch_super('on_key_release', symbol, modifiers)
         if not self.scene:
             return
         self.scene.on_key_release(symbol, modifiers)
 
     @note_undrawn_event
     def on_resize(self, width: int, height: int) -> None:
-        super().on_resize(width, height)
+        self._dispatch_super('on_resize', width, height)
+        if hasattr(self, 'ctx'):
+            self.ctx.viewport = (0, 0, width, height)
         if not self.scene:
             return
         self.scene.on_resize(width, height)
 
     @note_undrawn_event
     def on_show(self) -> None:
+        self._dispatch_super('on_show')
         if not self.scene:
             return
         self.scene.on_show()
 
     @note_undrawn_event
     def on_hide(self) -> None:
+        self._dispatch_super('on_hide')
         if not self.scene:
             return
         self.scene.on_hide()
 
     @note_undrawn_event
     def on_close(self) -> None:
-        super().on_close()
+        self._dispatch_super('on_close')
         self._is_closing = True
         if not self.scene:
             return

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -189,11 +189,6 @@ class Window(PygletWindow):
         self.flip()
         self._has_undrawn_event = False
 
-    def _dispatch_super(self, name: str, *args, **kwargs) -> None:
-        handler = getattr(super(), name, None)
-        if handler:
-            handler(*args, **kwargs)
-
     @staticmethod
     def note_undrawn_event(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
@@ -204,7 +199,6 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_mouse_motion(self, x: int, y: int, dx: int, dy: int) -> None:
-        self._dispatch_super('on_mouse_motion', x, y, dx, dy)
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
@@ -213,7 +207,6 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_mouse_drag(self, x: int, y: int, dx: int, dy: int, buttons: int, modifiers: int) -> None:
-        self._dispatch_super('on_mouse_drag', x, y, dx, dy, buttons, modifiers)
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
@@ -222,7 +215,6 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_mouse_press(self, x: int, y: int, button: int, mods: int) -> None:
-        self._dispatch_super('on_mouse_press', x, y, button, mods)
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
@@ -230,7 +222,6 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_mouse_release(self, x: int, y: int, button: int, mods: int) -> None:
-        self._dispatch_super('on_mouse_release', x, y, button, mods)
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
@@ -238,7 +229,6 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_mouse_scroll(self, x: int, y: int, x_offset: float, y_offset: float) -> None:
-        self._dispatch_super('on_mouse_scroll', x, y, x_offset, y_offset)
         if not self.scene:
             return
         point = self.pixel_coords_to_space_coords(x, y)
@@ -247,8 +237,8 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_key_press(self, symbol: int, modifiers: int) -> None:
+        super().on_key_press(symbol, modifiers)
         self.pressed_keys.add(symbol)  # Modifiers?
-        self._dispatch_super('on_key_press', symbol, modifiers)
         if not self.scene:
             return
         self.scene.on_key_press(symbol, modifiers)
@@ -256,14 +246,12 @@ class Window(PygletWindow):
     @note_undrawn_event
     def on_key_release(self, symbol: int, modifiers: int) -> None:
         self.pressed_keys.difference_update({symbol})  # Modifiers?
-        self._dispatch_super('on_key_release', symbol, modifiers)
         if not self.scene:
             return
         self.scene.on_key_release(symbol, modifiers)
 
     @note_undrawn_event
     def on_resize(self, width: int, height: int) -> None:
-        self._dispatch_super('on_resize', width, height)
         if hasattr(self, 'ctx'):
             self.ctx.viewport = (0, 0, width, height)
         if not self.scene:
@@ -272,21 +260,19 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_show(self) -> None:
-        self._dispatch_super('on_show')
         if not self.scene:
             return
         self.scene.on_show()
 
     @note_undrawn_event
     def on_hide(self) -> None:
-        self._dispatch_super('on_hide')
         if not self.scene:
             return
         self.scene.on_hide()
 
     @note_undrawn_event
     def on_close(self) -> None:
-        self._dispatch_super('on_close')
+        super().on_close()
         self._is_closing = True
         if not self.scene:
             return

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -262,14 +262,12 @@ class Window(PygletWindow):
 
     @note_undrawn_event
     def on_show(self) -> None:
-        super().on_show()
         if not self.scene:
             return
         self.scene.on_show()
 
     @note_undrawn_event
     def on_hide(self) -> None:
-        super().on_hide()
         if not self.scene:
             return
         self.scene.on_hide()

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -52,6 +52,8 @@ class Window(PygletWindow):
             major_version=self.gl_version[0],
             minor_version=self.gl_version[1],
             double_buffer=True,
+            depth_size=24,
+            stencil_size=8,
         )
 
         pyglet.app.platform_event_loop.start()
@@ -179,7 +181,7 @@ class Window(PygletWindow):
 
     def clear(self, r: float = 0.0, g: float = 0.0, b: float = 0.0, a: float = 1.0) -> None:
         if hasattr(self, "ctx"):
-            self.ctx.clear(r, g, b, a)
+            self.ctx.clear(r, g, b, a, depth=1.0)
         else:
             super().clear()
 

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -54,6 +54,8 @@ class Window(PygletWindow):
             double_buffer=True,
         )
 
+        pyglet.app.platform_event_loop.start()
+
         super().__init__(
             width=self.default_size[0],
             height=self.default_size[1],
@@ -292,3 +294,4 @@ class Window(PygletWindow):
         if hasattr(self, "ctx"):
             self.ctx.release()
         self.close()
+        pyglet.app.platform_event_loop.stop()

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import numpy as np
-
-import moderngl_window as mglw
-from moderngl_window.context.pyglet.window import Window as PygletWindow
-from moderngl_window.timers.clock import Timer
 from functools import wraps
+
+import moderngl
+import numpy as np
+import pyglet
 import screeninfo
+
+from pyglet.window import Window as PygletWindow
 
 from manimlib.constants import ASPECT_RATIO
 from manimlib.constants import FRAME_SHAPE
@@ -35,15 +36,33 @@ class Window(PygletWindow):
         full_screen: bool = False,
         size: Optional[tuple[int, int]] = None,
         position: Optional[tuple[int, int]] = None,
-        samples: int = 0
+        samples: int = 0,
     ):
         self.scene = scene
         self.monitor = self.get_monitor(monitor_index)
         self.default_size = size or self.get_default_size(full_screen)
         self.default_position = position or self.position_from_string(position_string)
         self.pressed_keys = set()
+        self._has_undrawn_event = True
 
-        super().__init__(samples=samples)
+        config = pyglet.gl.Config(
+            sample_buffers=1 if samples > 0 else 0,
+            samples=samples,
+            major_version=self.gl_version[0],
+            minor_version=self.gl_version[1],
+            double_buffer=True,
+        )
+
+        super().__init__(
+            width=self.default_size[0],
+            height=self.default_size[1],
+            resizable=self.resizable,
+            vsync=self.vsync,
+            fullscreen=full_screen,
+            config=config,
+        )
+
+        self.set_mouse_visible(self.cursor)
         self.to_default_position()
 
         if self.scene:
@@ -60,17 +79,32 @@ class Window(PygletWindow):
         self._has_undrawn_event = True
 
         self.scene = scene
-        self.title = str(scene)
+        self.set_caption(str(scene))
 
         self.init_mgl_context()
 
-        self.timer = Timer()
-        self.config = mglw.WindowConfig(ctx=self.ctx, wnd=self, timer=self.timer)
-        mglw.activate_context(window=self, ctx=self.ctx)
-        self.timer.start()
-
         # This line seems to resync the viewport
         self.on_resize(*self.size)
+
+    def init_mgl_context(self) -> None:
+        self.ctx = moderngl.create_context()
+
+    # Helper properties for width/height and position
+    @property
+    def size(self) -> tuple[int, int]:
+        return (self.width, self.height)
+
+    @size.setter
+    def size(self, size: tuple[int, int]) -> None:
+        self.set_size(*size)
+
+    @property
+    def position(self) -> tuple[int, int]:
+        return self.get_location()
+
+    @position.setter
+    def position(self, pos: tuple[int, int]) -> None:
+        self.set_location(*pos)
 
     def get_monitor(self, index):
         try:
@@ -105,8 +139,8 @@ class Window(PygletWindow):
         flicker on the window but at least reliably focuses it. It may also
         offset the window position slightly.
         """
-        self._window.set_visible(False)
-        self._window.set_visible(True)
+        self.set_visible(False)
+        self.set_visible(True)
 
     def to_default_position(self):
         self.position = self.default_position
@@ -139,8 +173,14 @@ class Window(PygletWindow):
     def has_undrawn_event(self) -> bool:
         return self._has_undrawn_event
 
-    def swap_buffers(self):
-        super().swap_buffers()
+    def clear(self, r: float = 0.0, g: float = 0.0, b: float = 0.0, a: float = 1.0) -> None:
+        if hasattr(self, "ctx"):
+            self.ctx.clear(r, g, b, a)
+        else:
+            super().clear()
+
+    def swap_buffers(self) -> None:
+        self.flip()
         self._has_undrawn_event = False
 
     @staticmethod

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -44,6 +44,7 @@ class Window(PygletWindow):
         self.default_position = position or self.position_from_string(position_string)
         self.pressed_keys = set()
         self._has_undrawn_event = True
+        self._is_closing = False
 
         config = pyglet.gl.Config(
             sample_buffers=1 if samples > 0 else 0,
@@ -274,9 +275,20 @@ class Window(PygletWindow):
     @note_undrawn_event
     def on_close(self) -> None:
         super().on_close()
+        self._is_closing = True
         if not self.scene:
             return
         self.scene.on_close()
 
     def is_key_pressed(self, symbol: int) -> bool:
         return (symbol in self.pressed_keys)
+
+    # Methods for compatibility with previous window wrapper
+    @property
+    def is_closing(self) -> bool:
+        return self._is_closing
+
+    def destroy(self) -> None:
+        if hasattr(self, "ctx"):
+            self.ctx.release()
+        self.close()

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -44,7 +44,6 @@ class Window(PygletWindow):
         self.default_position = position or self.position_from_string(position_string)
         self.pressed_keys = set()
         self._has_undrawn_event = True
-        self._is_closing = False
 
         config = pyglet.gl.Config(
             sample_buffers=1 if samples > 0 else 0,
@@ -273,7 +272,6 @@ class Window(PygletWindow):
     @note_undrawn_event
     def on_close(self) -> None:
         super().on_close()
-        self._is_closing = True
         if not self.scene:
             return
         self.scene.on_close()
@@ -284,7 +282,7 @@ class Window(PygletWindow):
     # Methods for compatibility with previous window wrapper
     @property
     def is_closing(self) -> bool:
-        return self._is_closing
+        return self.has_exit
 
     def destroy(self) -> None:
         if hasattr(self, "ctx"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@ manimpango>=0.6.0
 mapbox-earcut
 matplotlib
 moderngl
-moderngl_window
 numpy
 Pillow
 pydub
+pyglet
 pygments
 PyOpenGL
 pyperclip

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,10 +41,10 @@ install_requires =
     mapbox-earcut
     matplotlib
     moderngl
-    moderngl_window
     numpy
     Pillow
     pydub
+    pyglet
     pygments
     PyOpenGL
     pyperclip


### PR DESCRIPTION
## Summary
- replace moderngl_window usage with a direct pyglet window implementation
- drop moderngl_window dependency and add pyglet to install requirements

## Testing
- `pip install -e .` *(failed: RequiredDependencyException: pangocairo >= 1.30.0 is required)*
- `pip install pyglet`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689500cacc54832a80908b0657fcefbb