### PR TITLE
Add scene aspect ratio lock option

### DIFF
--- a/manimlib/default_config.yml
+++ b/manimlib/default_config.yml
@@ -69,6 +69,7 @@ scene:
   preview_while_skipping: True
   # How long does a scene pause on Scene.wait calls
   default_wait_time: 1.0
+  fixed_aspect_ratio: False
 vmobject:
   default_stroke_width: 4.0
   default_stroke_color: "#DDDDDD"     # Default is GREY_A

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -112,6 +112,9 @@ class Scene(object):
             samples=self.samples,
             **self.camera_config
         )
+        if self.fixed_aspect_ratio:
+            # Ensure the initial frame respects the desired aspect ratio
+            self.camera.resize_frame_shape(fixed_dimension=True)
         self.frame: CameraFrame = self.camera.frame
         self.frame.reorient(*self.default_frame_orientation)
         self.frame.make_orientation_default()
@@ -860,7 +863,7 @@ class Scene(object):
             self.hold_on_wait = False
 
     def on_resize(self, width: int, height: int) -> None:
-        if self.fixed_aspect_ratio:
+        if self.fixed_aspect_ratio and hasattr(self, "camera"):
             self.camera.resize_frame_shape(fixed_dimension=True)
 
     def on_show(self) -> None:

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -76,6 +76,7 @@ class Scene(object):
         preview_while_skipping: bool = True,
         presenter_mode: bool = False,
         default_wait_time: float = 1.0,
+        fixed_aspect_ratio: bool = False,
     ):
         self.skip_animations = skip_animations
         self.always_update_mobjects = always_update_mobjects
@@ -86,6 +87,7 @@ class Scene(object):
         self.preview_while_skipping = preview_while_skipping
         self.presenter_mode = presenter_mode
         self.default_wait_time = default_wait_time
+        self.fixed_aspect_ratio = fixed_aspect_ratio
 
         self.camera_config = merge_dicts_recursively(
             manim_config.camera,         # Global default
@@ -858,7 +860,8 @@ class Scene(object):
             self.hold_on_wait = False
 
     def on_resize(self, width: int, height: int) -> None:
-        pass
+        if self.fixed_aspect_ratio:
+            self.camera.resize_frame_shape(fixed_dimension=True)
 
     def on_show(self) -> None:
         pass

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -112,9 +112,9 @@ class Scene(object):
             samples=self.samples,
             **self.camera_config
         )
-        if self.fixed_aspect_ratio:
-            # Ensure the initial frame respects the desired aspect ratio
-            self.camera.resize_frame_shape(fixed_dimension=True)
+        if self.window:
+            # Ensure viewport or frame matches current window size
+            self.on_resize(*self.window.size)
         self.frame: CameraFrame = self.camera.frame
         self.frame.reorient(*self.default_frame_orientation)
         self.frame.make_orientation_default()
@@ -863,8 +863,26 @@ class Scene(object):
             self.hold_on_wait = False
 
     def on_resize(self, width: int, height: int) -> None:
-        if self.fixed_aspect_ratio and hasattr(self, "camera"):
-            self.camera.resize_frame_shape(fixed_dimension=True)
+        if not hasattr(self, "camera"):
+            return
+
+        if self.fixed_aspect_ratio:
+            aspect = self.camera.frame.get_aspect_ratio()
+            window_aspect = width / height
+            if window_aspect > aspect:
+                vp_height = height
+                vp_width = int(aspect * vp_height)
+                vp_x = (width - vp_width) // 2
+                vp_y = 0
+            else:
+                vp_width = width
+                vp_height = int(vp_width / aspect)
+                vp_x = 0
+                vp_y = (height - vp_height) // 2
+            if self.window:
+                self.window.ctx.viewport = (vp_x, vp_y, vp_width, vp_height)
+        else:
+            self.camera.resize_frame_shape()
 
     def on_show(self) -> None:
         pass

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -863,22 +863,17 @@ class Scene(object):
             self.hold_on_wait = False
 
     def on_resize(self, width: int, height: int) -> None:
-        if not hasattr(self, "camera"):
-            return
-
         if self.fixed_aspect_ratio:
             aspect = self.camera.frame.get_aspect_ratio()
             window_aspect = width / height
             if window_aspect > aspect:
                 vp_height = height
-                vp_width = int(aspect * vp_height)
-                vp_x = (width - vp_width) // 2
-                vp_y = 0
+                vp_width = int(vp_height * aspect)
             else:
                 vp_width = width
                 vp_height = int(vp_width / aspect)
-                vp_x = 0
-                vp_y = (height - vp_height) // 2
+            vp_x = (width - vp_width) // 2
+            vp_y = (height - vp_height) // 2
             if self.window:
                 self.window.ctx.viewport = (vp_x, vp_y, vp_width, vp_height)
         else:

--- a/manimlib/scene/scene.py
+++ b/manimlib/scene/scene.py
@@ -863,6 +863,9 @@ class Scene(object):
             self.hold_on_wait = False
 
     def on_resize(self, width: int, height: int) -> None:
+        if not hasattr(self, 'camera'):
+            return
+
         if self.fixed_aspect_ratio:
             aspect = self.camera.frame.get_aspect_ratio()
             window_aspect = width / height
@@ -876,8 +879,6 @@ class Scene(object):
             vp_y = (height - vp_height) // 2
             if self.window:
                 self.window.ctx.viewport = (vp_x, vp_y, vp_width, vp_height)
-        else:
-            self.camera.resize_frame_shape()
 
     def on_show(self) -> None:
         pass

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -90,8 +90,9 @@ class Window(PygletWindow):
 
         self.init_mgl_context()
 
-        # This line seems to resync the viewport
-        self.on_resize(*self.size)
+        if hasattr(scene, "camera"):
+            # Resync the viewport when the camera exists
+            self.on_resize(*self.size)
 
     def init_mgl_context(self) -> None:
         self.ctx = moderngl.create_context()

--- a/manimlib/window.py
+++ b/manimlib/window.py
@@ -90,9 +90,8 @@ class Window(PygletWindow):
 
         self.init_mgl_context()
 
-        if hasattr(scene, "camera"):
-            # Resync the viewport when the camera exists
-            self.on_resize(*self.size)
+        # This line seems to resync the viewport
+        self.on_resize(*self.size)
 
     def init_mgl_context(self) -> None:
         self.ctx = moderngl.create_context()


### PR DESCRIPTION
## Summary
- allow scenes to keep a fixed aspect ratio when window is resized
- expose `fixed_aspect_ratio` config option with default `False`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b274aefc832aa46edbc0e987614a